### PR TITLE
cached up corpusFrecuency

### DIFF
--- a/lorca.js
+++ b/lorca.js
@@ -5,6 +5,8 @@ const stemmer = require('./src/stemmer.js');
 const syllabler = require('./src/syllabler.js');
 const sentimenter = require('./src/sentimenter.js');
 
+var cachedList
+
 var lorca = function(input)
 {
     var wrapper = new Lorca();
@@ -459,7 +461,7 @@ class Lorca
 
     corpusFrequency(token)
     {
-        var list = require('./dictionaries/frequencyListRAE50000.json', 'utf8');
+        var list = cachedList = cachedList || require('./dictionaries/frequencyListRAE50000.json', 'utf8');
 
         if(token){            
             return list[token];


### PR DESCRIPTION
The first time corpusFrecuency is called, we do execute `require('./dictionaries/frequencyListRAE50000.json', 'utf8')` and we store his value in the local `list` variable and in the global `cachedList` variable so in the consecuents calls, we use the cached value

It posibly could be done better, but that was 100% free seccond effect way